### PR TITLE
Fix: `NameError: name 'np' is not defined` in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,11 @@
 import streamlit as st
+import numpy as np
 from calculate_conditions import calculate_conditions
 from image_processor import ScoreImageProcessor
 from typing import Dict, Any
 import tempfile
 import os
+import cv2
 
 # 定数定義
 PLAYERS = ['自分', '下家', '対面', '上家']


### PR DESCRIPTION
The function `process_uploaded_image_debug` in `app.py` uses `np` (for numpy) and `cv2` (for OpenCV) without importing them first. This causes a `NameError` when the "検出領域を表示" (Display detection area) button is clicked.

This commit adds the necessary import statements for `numpy` and `cv2` to the top of `app.py`, resolving the error.