### PR TITLE
fix: 7セグメント数字の切り出し処理を改善

### DIFF
--- a/image_processor.py
+++ b/image_processor.py
@@ -159,8 +159,12 @@ class ScoreImageProcessor:
         """
         スコア表示領域の画像から、輪郭検出を用いて5つの数字領域を分割する。
         """
+        # 数字同士の連結を断ち切るために収縮処理を行う
+        kernel = np.ones((3,3),np.uint8)
+        eroded_image = cv2.erode(image, kernel, iterations = 1)
+
         # 輪郭を検出
-        contours, _ = cv2.findContours(image, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        contours, _ = cv2.findContours(eroded_image, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
 
         # 輪郭を面積でフィルタリングして、小さすぎるノイズを除去
         min_contour_area = (image.shape[0] * image.shape[1]) * 0.01


### PR DESCRIPTION
ユーザーからのフィードバックに基づき、数字の切り出しが失敗する問題を修正します。

数字が連結している場合に輪郭検出がうまく機能しない問題に対処するため、`_split_digits`メソッドに収縮処理を追加しました。

これにより、連結したコンポーネントが分離され、各桁の輪郭をより正確に検出できるようになります。