### PR TITLE
fix: Apply hardcoded 9-degree shear correction

### DIFF
--- a/app.py
+++ b/app.py
@@ -138,10 +138,7 @@ def render_image_upload_section() -> Dict[str, int]:
 
                 if 'shear_corrected_screen' in debug_bundle:
                     st.markdown("##### 3. せん断補正後のスクリーン全体")
-                    st.image(debug_bundle['shear_corrected_screen'], caption="スクリーン全体にせん断補正を適用", use_container_width=True)
-                    if 'shear_angles' in debug_bundle and 'screen' in debug_bundle['shear_angles']:
-                        angle = debug_bundle['shear_angles']['screen']
-                        st.metric(label="検出された全体の傾き", value=f"{angle:.2f}°")
+                    st.image(debug_bundle['shear_corrected_screen'], caption="スクリーン全体にせん断補正を適用 (9°で固定)", use_container_width=True)
 
                 if 'deskewed_digits' in debug_bundle and debug_bundle['deskewed_digits']:
                     st.markdown("##### 4. 最終的な切り出し数字")
@@ -152,7 +149,7 @@ def render_image_upload_section() -> Dict[str, int]:
                             continue
 
                         # PILに変換して結合
-                        pil_images = [Image.fromarray(d) for d in digits if d.size > 0]
+                        pil_images = [Image.fromarray(d) for d in digits if d and d.size > 0]
                         if pil_images:
                             widths, heights = zip(*(i.size for i in pil_images))
                             total_width = sum(widths)


### PR DESCRIPTION
This commit implements a diagnostic test to validate the correct shear angle. Based on user feedback, the automatic angle detection in `_correct_shear` is temporarily replaced with a hardcoded 9-degree correction.

The full digit recognition pipeline has been re-enabled. This allows testing the entire process (screen detection, perspective warp, shear correction, splitting, and recognition) with a known, fixed correction angle.

This will help confirm if 9 degrees is the correct angle and if the rest of the pipeline is functioning correctly with a properly deskewed image.