### PR TITLE
fix: Resolve ValueError in debug image display

### DIFF
--- a/app.py
+++ b/app.py
@@ -149,7 +149,7 @@ def render_image_upload_section() -> Dict[str, int]:
                             continue
 
                         # PILに変換して結合
-                        pil_images = [Image.fromarray(d) for d in digits if d and d.size > 0]
+                        pil_images = [Image.fromarray(d) for d in digits if d is not None and d.size > 0]
                         if pil_images:
                             widths, heights = zip(*(i.size for i in pil_images))
                             total_width = sum(widths)


### PR DESCRIPTION
This commit fixes a `ValueError` that occurred in the Streamlit app (`app.py`) when displaying debug images.

The error was caused by an incorrect boolean check on a numpy array in a list comprehension. The code `if d` was ambiguous for a numpy array. This has been corrected to `if d is not None`, which is the proper way to check for the existence of the array object.