### PR TITLE
test: Use a 40-degree angle for shear correction diagnostic

### DIFF
--- a/image_processor.py
+++ b/image_processor.py
@@ -95,8 +95,8 @@ class ScoreImageProcessor:
             return []
 
     def _correct_shear(self, image: np.ndarray) -> Tuple[np.ndarray, float]:
-        """診断のため、せん断角度を9度に固定して補正する"""
-        dominant_angle_deg = 9.0
+        """診断のため、せん断角度を40度に固定して補正する"""
+        dominant_angle_deg = 40.0
         deviation_rad = np.radians(-dominant_angle_deg)
         shear_factor = np.tan(deviation_rad)
         M = np.array([[1, shear_factor, 0], [0, 1, 0]], dtype=np.float32)


### PR DESCRIPTION
This commit modifies the shear correction function to use a hardcoded, extreme angle of 40 degrees.

This is a diagnostic step to confirm that the `warpAffine` function is being called correctly and is having a visible effect on the image. The user reported that a 9-degree correction was not visible, so this test with an extreme value will help determine if the issue is with the correction logic itself or with the image transformation function.