### PR TITLE
fix(image): Re-binarize image after shear correction

### DIFF
--- a/image_processor.py
+++ b/image_processor.py
@@ -129,6 +129,7 @@ class ScoreImageProcessor:
         M = np.array([[1, shear_factor, 0], [0, 1, 0]], dtype=np.float32)
         (h, w) = image.shape[:2]
         corrected_image = cv2.warpAffine(image, M, (w, h), flags=cv2.INTER_CUBIC, borderMode=cv2.BORDER_CONSTANT, borderValue=0)
+        _, corrected_image = cv2.threshold(corrected_image, 127, 255, cv2.THRESH_BINARY)
 
         dominant_angle_deg = np.degrees(dominant_deviation_rad)
         return corrected_image, dominant_angle_deg
@@ -142,6 +143,7 @@ class ScoreImageProcessor:
         M = np.array([[1, shear_factor, 0], [0, 1, 0]], dtype=np.float32)
         (h, w) = image.shape[:2]
         corrected_image = cv2.warpAffine(image, M, (w, h), flags=cv2.INTER_CUBIC, borderMode=cv2.BORDER_CONSTANT, borderValue=0)
+        _, corrected_image = cv2.threshold(corrected_image, 127, 255, cv2.THRESH_BINARY)
 
         return corrected_image, angle_deg
 
@@ -193,6 +195,7 @@ class ScoreImageProcessor:
         M = np.array([[1, shear_factor, 0], [0, 1, 0]], dtype=np.float32)
         (h, w) = image.shape[:2]
         corrected_image = cv2.warpAffine(image, M, (w, h), flags=cv2.INTER_CUBIC, borderMode=cv2.BORDER_CONSTANT, borderValue=0)
+        _, corrected_image = cv2.threshold(corrected_image, 127, 255, cv2.THRESH_BINARY)
 
         dominant_angle_deg = np.degrees(dominant_deviation_rad)
         return corrected_image, dominant_angle_deg


### PR DESCRIPTION
The shear correction process, which involves `cv2.warpAffine`, introduces interpolation artifacts that convert the binary image into a grayscale one. This grayscale image was then passed to the `_split_digits` function, which relies on `cv2.findContours`. This caused the contour detection to fail, leading to incorrect digit splitting.

This commit fixes the issue by adding a `cv2.threshold` call after `warpAffine` in all three shear correction functions (`_correct_shear_hough`, `_correct_shear_manual`, `_correct_shear_zeros`). This ensures that a clean binary image is always passed to the subsequent digit splitting logic.